### PR TITLE
Fix table writer log statement

### DIFF
--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/exec/TableWriter.h"
 
+#include <folly/logging/xlog.h>
+
 #include "velox/exec/HashAggregation.h"
 #include "velox/exec/Task.h"
 
@@ -382,18 +384,16 @@ uint64_t TableWriter::ConnectorReclaimer::reclaim(
 
   auto* writer = dynamic_cast<TableWriter*>(op_);
   if (writer->closed_) {
-    // TODO: reduce the log frequency if it is too verbose.
     ++stats.numNonReclaimableAttempts;
-    LOG(WARNING) << "Can't reclaim from a closed writer connector pool: "
+    FB_LOG_EVERY_MS(WARNING, 1000) << "Can't reclaim from a closed writer connector pool: "
                  << pool->name()
                  << ", memory usage: " << succinctBytes(pool->reservedBytes());
     return 0;
   }
 
   if (writer->dataSink_ == nullptr) {
-    // TODO: reduce the log frequency if it is too verbose.
     ++stats.numNonReclaimableAttempts;
-    LOG(WARNING)
+    FB_LOG_EVERY_MS(WARNING, 1000)
         << "Can't reclaim from a writer connector pool which hasn't initialized yet: "
         << pool->name()
         << ", memory usage: " << succinctBytes(pool->reservedBytes());


### PR DESCRIPTION
Replace `LOG(WARNING)` with `FB_LOG_EVERY_MS` in `ConnectorReclaimer::reclaim` to reduce log spam from frequent warnings.

---
<a href="https://cursor.com/background-agent?bcId=bc-077b733b-2168-43a8-889e-12b7705ed508">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-077b733b-2168-43a8-889e-12b7705ed508">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

